### PR TITLE
jQuery 3 compatibility

### DIFF
--- a/build/jquery.images-compare.js
+++ b/build/jquery.images-compare.js
@@ -59,11 +59,11 @@
                     onImageLoaded();
                 } else {
                     // Image loading / error
-                    $(this).load(function() {
+                    $(this).on('load', function() {
                         elementsLoaded++;
                         onImageLoaded();
                     });
-                    $(this).error(function() {
+                    $(this).on('error', function() {
                         elementsLoaded++;
                         onImageLoaded();
                     });


### PR DESCRIPTION
jQuery 3.0 introduced a breaking change. This is also supported on previous versions of jQuery.

https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed